### PR TITLE
Dockerize WSIMOD

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,5 @@
+*
+!requirements.txt
+!wsimod
+!pyproject.toml
+!LICENSE

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,8 @@
 FROM python:3.11.5-alpine
 
-COPY requirements.txt .
-RUN pip install --no-cache-dir -r requirements.txt
-
 COPY --chown=nobody . /usr/src/app
 WORKDIR /usr/src/app
+RUN pip install --no-cache-dir -r requirements.txt
 RUN pip install .
 USER nobody
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,13 @@
+FROM python:3.11.5-alpine
+
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+
+COPY --chown=nobody . /usr/src/app
+WORKDIR /usr/src/app
+RUN pip install .
+USER nobody
+
+ENV WSIMOD_SETTINGS settings.yaml
+
+CMD wsimod /data/inputs/${WSIMOD_SETTINGS} --inputs /data/inputs --outputs /data/outputs

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,0 +1,10 @@
+version: '3'
+services:
+  wsimod:
+    build: .
+    environment:
+      - WSIMOD_SETTINGS=settings.yaml
+    volumes:
+      - .:/usr/src/app
+      - ./scratch:/data/inputs
+      - ./scratch:/data/outputs

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -2,9 +2,9 @@ version: '3'
 services:
   wsimod:
     build: .
-    environment:
-      - WSIMOD_SETTINGS=settings.yaml
+    env_file:
+      - .env
     volumes:
       - .:/usr/src/app
-      - ./scratch:/data/inputs
-      - ./scratch:/data/outputs
+      - ${WSIMOD_INPUTS}:/data/inputs
+      - ${WSIMOD_OUTPUTS}:/data/outputs


### PR DESCRIPTION
This PR dockerize the execution of WSIMOD and adds a `docker-compose` file to facilitate local testing and deployment. 

To be reviewed and merged after #38 , as it builds on top of it. 

Closes #25 