### PR TITLE
Add running WSIMOD saved files

### DIFF
--- a/wsimod/validation.py
+++ b/wsimod/validation.py
@@ -29,7 +29,7 @@ def evaluate_input_file(settings: Path) -> Literal["saved", "custom"]:
     with settings.open("rb") as f:
         settings_ = yaml.safe_load(f)
 
-    if set(["file", "inputs", "outputs"]).isdisjoint(settings_.keys()):
+    if set(["data", "inputs", "outputs"]).isdisjoint(settings_.keys()):
         return "saved"
 
     return "custom"

--- a/wsimod/validation.py
+++ b/wsimod/validation.py
@@ -1,12 +1,38 @@
 import ast
 import os
 from pathlib import Path
-from typing import Any, Optional, Union
+from typing import Any, Literal, Optional, Union
 
 import pandas as pd
 import yaml
 
 from wsimod.core import constants
+
+
+def evaluate_input_file(settings: Path) -> Literal["saved", "custom"]:
+    """Decides what type of input file we are dealing with.
+
+    "save" correspond to fully constructed models which have been saved, alongside
+    any necessary data files. "custom" are input files constructed manually.
+
+    Raises:
+        ValueError: If the settings file do not exist.
+
+    Return:
+        If the input file is a saved model file or a custom input.
+    """
+    if settings.is_dir() or not settings.exists():
+        raise ValueError(
+            f"The settings file at {settings.absolute()} could not be found."
+        )
+
+    with settings.open("rb") as f:
+        settings_ = yaml.safe_load(f)
+
+    if set(["file", "inputs", "outputs"]).isdisjoint(settings_.keys()):
+        return "saved"
+
+    return "custom"
 
 
 def validate_io_args(


### PR DESCRIPTION
This PR adds the ability to directly run WSIMOD from [previously saved config files](https://imperialcollegelondon.github.io/wsi/wsimod_models/), created with `Model.save`. This is less flexible, as the model needs to have been created manually beforehand, but it might be convenient for complex models for which the input data files need to be heavily pre-processed, beyond what the existing setup can handle. 

To try this, run one of the existing tutorials but saving the model before running the model itself (you can finish the execution after saving the model). A yaml file a csv file witll be produced. Then, run WSIMOD from the command line passing this yaml file... and if all goes well, it should run.