### PR TITLE
Add apply_overrides

### DIFF
--- a/tests/test_arcs.py
+++ b/tests/test_arcs.py
@@ -313,6 +313,18 @@ class MyTestClass(TestCase):
         d1["phosphate"] = d1["phosphate"] * (1 - 0.005 * 1.005 ** (10 - 20))
         self.assertDictAlmostEqual(d1, arc1.queue[0])
 
+    def test_apply_overrides(self):
+        node1, node2, _, _, _, arc1, _, _, _ = self.get_simple_model1()
+        arc1.apply_overrides({'name' : 'new_name'})
 
+        self.assertEqual('new_name', arc1.name)
+        assert 'new_name' in node1.out_arcs.keys()
+        assert 'new_name' in node1.out_arcs_type['Waste'].keys()
+        assert 'arc1' not in node1.out_arcs.keys()
+
+        assert 'new_name' in node2.in_arcs.keys()
+        assert 'new_name' in node2.in_arcs_type['Storage'].keys()
+        assert 'arc1' not in node2.in_arcs.keys()
+        
 if __name__ == "__main__":
     unittest.main()

--- a/wsimod/nodes/nodes.py
+++ b/wsimod/nodes/nodes.py
@@ -6,6 +6,7 @@
 Converted to totals on Thur Apr 21 2022
 """
 import logging
+from typing import Any, Dict
 
 from wsimod.arcs.arcs import AltQueueArc, DecayArcAlt
 from wsimod.core import constants
@@ -76,7 +77,23 @@ class Node(WSIObj):
         # Mass balance checking
         self.mass_balance_in = [self.total_in]
         self.mass_balance_out = [self.total_out]
-        self.mass_balance_ds = [lambda: self.empty_vqip()]
+        self.mass_balance_ds = [lambda: self.empty_vqip()]        
+
+    def apply_overrides(self, 
+                        overrides: Dict[str, Any] = {}) -> None:
+        """Apply overrides to the node.
+
+        Args:
+            overrides (dict, optional): Dictionary of overrides. Defaults to {}.
+
+        Example:
+            >>> my_node.apply_overrides({'name': 'new_name'})
+        """
+        for key, value in overrides.items():
+            if hasattr(self, key):
+                setattr(self, key, value)
+            else:
+                raise AttributeError(f"{key} not found in {self.__class__.__name__}")
 
     def total_in(self):
         """Sum flow and pollutant amounts entering a node via in_arcs.


### PR DESCRIPTION
Addresses: #67 

@dalonsoa @liuly12 

So the simplest first issue on this I've had a go at it. 

I think it is sensible that `apply_overrides` by default just sets parameters to the `overrides` values, does this mean that we have to add a list of 'not overwritable' parameters (for example, if people want to start editing `handlers` that should probably be done by a new subclass). I have included a use example for the `name` parameter in the `Arc`. I'm not sure we are suggesting that it is a good idea to change the name - but I guess if we allow it this is how to do it. 

Great to hear thoughts - on writing this example I am thinking that @dalonsoa 's first code (which implicitly assumes that by default no parameters are overwritable) is probably more sensible. For now you can just view this PR as the counter example.