### PR TITLE
Extensions: decorators

### DIFF
--- a/docs/demo/scripts/customise_interactions.py
+++ b/docs/demo/scripts/customise_interactions.py
@@ -339,10 +339,13 @@ print(
 
 # %%
 from wsimod.extensions import extensions as extend
-@extend.model_attribute(obj=my_fwtw, attribute_name="pull_distributed")
+
+
+@extend.node_attribute(obj=my_fwtw, attribute_name="pull_distributed")
 def new_distributed(pull_distributed, vqip):
-     """pull_distributed with the tag 'FWTW'."""
-     return pull_distributed(vqip, tag="FWTW")
+    """pull_distributed with the tag 'FWTW'."""
+    return pull_distributed(vqip, tag="FWTW")
+
 
 # %% [markdown]
 # Explaining decorators is outside the scope of this tutorial, though you can

--- a/docs/demo/scripts/customise_interactions.py
+++ b/docs/demo/scripts/customise_interactions.py
@@ -338,31 +338,11 @@ print(
 
 
 # %%
-def wrap(func):
-    """
-
-    Args:
-        func:
-
-    Returns:
-
-    """
-
-    def pull_distributed_wrapper(x):
-        """
-
-        Args:
-            x:
-
-        Returns:
-
-        """
-        return func(x, tag="FWTW")
-
-    return pull_distributed_wrapper
-
-
-my_fwtw.pull_distributed = wrap(my_fwtw.pull_distributed)
+from wsimod.extensions import extensions as extend
+@extend.model_attribute(obj=my_fwtw, attribute_name="pull_distributed")
+def new_distributed(pull_distributed, vqip):
+     """pull_distributed with the tag 'FWTW'."""
+     return pull_distributed(vqip, tag="FWTW")
 
 # %% [markdown]
 # Explaining decorators is outside the scope of this tutorial, though you can

--- a/wsimod/extensions/extensions.py
+++ b/wsimod/extensions/extensions.py
@@ -1,0 +1,33 @@
+def model_attribute(obj, attribute_name):
+    """
+    Decorator to extend or modify a model attribute.
+
+    Args:
+        obj: The model object whose attribute should be modified.
+        attribute_name (str): The name of the attribute to modify.
+
+    Returns:
+        A decorator function that takes the extension function as an argument.
+    """
+    def decorator(func):
+        """
+        Decorator function that applies the extension function to the model attribute.
+
+        Args:
+            func: The extension function that modifies the model attribute.
+        """
+        attribute = getattr(obj, attribute_name)
+        
+        def wrapped_attribute(*args, **kwargs):
+            return func(attribute, *args, **kwargs)
+
+        setattr(obj, attribute_name, wrapped_attribute)
+        return wrapped_attribute
+
+    return decorator
+
+    
+@model_attribute(obj=my_fwtw, attribute_name="pull_distributed")
+def new_distributed(pull_distributed, vqip):
+     """pull_distributed with the tag 'FWTW'."""
+     return pull_distributed(vqip, tag="FWTW")

--- a/wsimod/extensions/extensions.py
+++ b/wsimod/extensions/extensions.py
@@ -25,9 +25,3 @@ def model_attribute(obj, attribute_name):
         return wrapped_attribute
 
     return decorator
-
-    
-@model_attribute(obj=my_fwtw, attribute_name="pull_distributed")
-def new_distributed(pull_distributed, vqip):
-     """pull_distributed with the tag 'FWTW'."""
-     return pull_distributed(vqip, tag="FWTW")

--- a/wsimod/extensions/extensions.py
+++ b/wsimod/extensions/extensions.py
@@ -1,23 +1,34 @@
-def model_attribute(obj, attribute_name):
+"""Extensions module for decorators and subclasses.
+
+Example use for decorators:
+>>> from wsimod.extensions import extensions as extend
+>>> @extend.node_attribute(obj=my_fwtw, attribute_name="pull_distributed")
+>>> def new_distributed(pull_distributed, vqip):
+>>>      return pull_distributed(vqip, tag="FWTW")
+"""
+
+
+def node_attribute(obj, attribute_name: str):
     """
-    Decorator to extend or modify a model attribute.
+    Decorator to extend or modify a node attribute.
 
     Args:
-        obj: The model object whose attribute should be modified.
+        obj: The node object whose attribute should be modified.
         attribute_name (str): The name of the attribute to modify.
 
     Returns:
         A decorator function that takes the extension function as an argument.
     """
-    def decorator(func):
+
+    def decorator(func: callable):
         """
-        Decorator function that applies the extension function to the model attribute.
+        Decorator function that applies the extension function to the node attribute.
 
         Args:
-            func: The extension function that modifies the model attribute.
+            func (callable): The extension function that modifies the node attribute.
         """
         attribute = getattr(obj, attribute_name)
-        
+
         def wrapped_attribute(*args, **kwargs):
             return func(attribute, *args, **kwargs)
 


### PR DESCRIPTION
# Description

My demonstration of decorators in the extensions file.

I have implemented it on one of the example tutorials.

If we're happy with it I think we will have two further issues:
- Decorators behaviour, where further functions are added in extensions (e.g., `extend.surface`, etc.)
- Decorators notebook, where we update existing tutorials with this new usage (they need updating anyway)

I think we will also want a notebook for extensions in general, but for me it makes sense to do this after we support subclasses via it.