### PR TITLE
make deprecation as warnings for rivers

### DIFF
--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -7,6 +7,7 @@
 
 # import pytest
 import unittest
+import warnings
 from unittest import TestCase
 
 from wsimod.arcs.arcs import Arc
@@ -399,10 +400,15 @@ class MyTestClass(TestCase):
                 self.assertEqual(river.tank.capacity, v)
             self.assertEqual(getattr(river, k), v)
         # test runtimeerrors
-        self.assertRaises(RuntimeError, lambda: river.apply_overrides({"area": 75.2}))
-        self.assertRaises(
-            RuntimeError, lambda: river.apply_overrides({"capacity": 123})
-        )
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            river.apply_overrides({"area": 75.2})
+            assert "specifying area is depreciated" in str(w[0]) 
+
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            river.apply_overrides({"capacity": 123})
+            assert "specifying capacity is depreciated" in str(w[0])
 
     def test_riverreservoir_overrides(self):
         riverreservoir = RiverReservoir(name="")

--- a/wsimod/nodes/storage.py
+++ b/wsimod/nodes/storage.py
@@ -3,6 +3,7 @@
 
 @author: bdobson Converted to totals on 2022-05-03
 """
+import warnings
 from math import exp
 from typing import Any, Dict
 
@@ -507,7 +508,7 @@ class River(Storage):
         # Set parameters
         self.depth = depth
         if depth != 2:
-            raise RuntimeError(
+            warnings.warn(
                 "warning: the depth parameter is unused by River nodes because it is \
 		intended for capacity to be unbounded. It may be removed in a future version."
             )
@@ -639,13 +640,13 @@ class River(Storage):
             setattr(self, param, overrides.pop(param))
 
         if "area" in overrides.keys():
-            raise RuntimeError(
-                "ERROR: specifying area is depreciated in overrides \
+            warnings.warn(
+                "WARNING: specifying area is depreciated in overrides \
 		for river, please specify length and width instead"
             )
         overrides["area"] = self.length * self.width
         if "capacity" in overrides.keys():
-            raise RuntimeError(
+            warnings.warn(
                 "ERROR: specifying capacity is depreciated in overrides \
 		for river, it is always set as unbounded capacity"
             )


### PR DESCRIPTION
There are `depth` and `capacity` parameters in nearly all of our WSIMOD models. I think rather than having to remove all these entries can we just make these deprecation notices as warnings?