### PR TITLE
Fix publish workflow

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -3,3 +3,5 @@
 !wsimod
 !pyproject.toml
 !LICENSE
+!.git
+!README.md

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -24,31 +24,7 @@ jobs:
         with:
           files: dist/wsimod*
 
-  publish-TestPyPI:
-    needs: build-wheel
-    name: Publish WSIMOD to TestPyPI
-    runs-on: ubuntu-latest
-    permissions:
-      id-token: write
-
-    steps:
-      - name: Download sdist artifact
-        uses: actions/download-artifact@v4
-        with:
-          name: artifact
-          path: dist
-
-      - name: Display structure of downloaded files
-        run: ls -R dist
-
-      - name: Publish package distributions to TestPyPI
-        uses: pypa/gh-action-pypi-publish@release/v1
-        with:
-          repository-url: https://test.pypi.org/legacy/
-          skip-existing: true
-
   publish-PyPI:
-    needs: publish-TestPyPI
     name: Publish WSIMOD to PyPI
     runs-on: ubuntu-latest
     permissions:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,12 @@
 FROM python:3.11.5-alpine
 
+RUN apk update && apk add git 
+
 COPY --chown=nobody . /usr/src/app
 WORKDIR /usr/src/app
 RUN pip install --no-cache-dir .
 USER nobody
 
-ENV WSIMOD_SETTINGS settings.yaml
+ENV WSIMOD_SETTINGS=settings.yaml
 
 CMD wsimod /data/inputs/${WSIMOD_SETTINGS} --inputs /data/inputs --outputs /data/outputs

--- a/wsimod/extensions.py
+++ b/wsimod/extensions.py
@@ -34,7 +34,7 @@ Example of patching an attribute item:
     >>>     return {}
 
 If patching a method of an attribute, the `is_attr` argument should be set to `True` and
-the target should include the attribute name and the method name, all separated by 
+the target should include the attribute name and the method name, all separated by
 periods, eg. `attribute_name.method_name`.
 
 It should be noted that the patched function should have the same signature as the
@@ -43,7 +43,7 @@ there will be a runtime error. In particular, the first argument of the patched 
 should be the node object itself, which will typically be named `self`.
 
 The overridden method or attribute can be accessed within the patched function using the
-`_patched_{method_name}` attribute of the object, eg. `self._patched_pull_distributed`. 
+`_patched_{method_name}` attribute of the object, eg. `self._patched_pull_distributed`.
 The exception to this is when patching an item, in which case the original item is no
 available to be used within the overriding function.
 


### PR DESCRIPTION
So that the generation of the Docker container works. Other failures shown in https://github.com/ImperialCollegeLondon/wsi/actions/workflows/publish.yml I feel are related to repeated attempts to run the workflow using the same tags/releases, resulting in inconsistent states for the repository.