### PR TITLE
:recycle: Update DAFNI upload command

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -80,7 +80,7 @@ jobs:
       - name: Create Docker image
         run: |
           docker build -t wsimod:$VERSION .
-          docker save -o wsimod-$VERSION.tar.gz wsimod:$VERSION
+          docker save -o wsimod.tar.gz wsimod:$VERSION
 
       - name: Install DAFNI API
         run: python -m pip install dafni-cli
@@ -89,4 +89,4 @@ jobs:
         run: dafni login
 
       - name: Upload updated model
-        run: dafni upload model model_file.yaml wsimod-$VERSION.tar.gz --parent-id $PARENT_ID -m "v$VERSION, see release notes."
+        run: dafni upload model model_file.yaml wsimod.tar.gz --parent-id $PARENT_ID -m "v$VERSION, see release notes." --yes


### PR DESCRIPTION
Essentially the problem was:
- The DAFNI command line tool does not like to have `.` in the model filename other than the ones in the extension, so I've removed the version information from the filename.
- There was a new flag `--yes` that was needed to skip any upload confirmation. Without it, it would just stay there, waiting for a response.

Hopefully, next time the upload will work.